### PR TITLE
Update async API method in line with changes in core HA

### DIFF
--- a/custom_components/anycubic_wifi/__init__.py
+++ b/custom_components/anycubic_wifi/__init__.py
@@ -6,7 +6,7 @@ rendered by the sensor entity.
 The init.py file is the entry point for the integration. It is responsible for
 creating the integration representation in hass.data.
 """
-# pylint disable=anomalous-backslash-in-string
+# pylint: disable=anomalous-backslash-in-string
 
 # The overall project layout is as follows:
 #             Init Config Entry
@@ -78,7 +78,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     :param entry: The config entry to setup.
     :returns: True if the setup was successful. This will always be successful
         barring problems with Home Assistant or the underlying APIs. In the
-        event a communication-type excepiton occurs, Home Assistant will
+        event a communication-type exception occurs, Home Assistant will
         declare this entry unable to be setup, requiring a reconfiguration or
         restart to bring us back online."""
     # setup the basic datastructure in hass.
@@ -93,10 +93,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     entry_location["coordinator"] = bridge
 
     # Setup the platforms.
-    try:
-        await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    except TypeError as err:
-        raise ConfigEntryNotReady from err
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     # Setup options listener.
     entry.async_on_unload(entry.add_update_listener(opt_update_listener))
@@ -135,9 +132,7 @@ async def opt_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
     except AttributeError:
         pass
     # setup the device again
-    await async_setup_entry(hass, entry)
     await hass.config_entries.async_reload(entry.entry_id)
-
 
 def get_existing_bridge(
     hass: HomeAssistant, entry: ConfigEntry

--- a/custom_components/anycubic_wifi/__init__.py
+++ b/custom_components/anycubic_wifi/__init__.py
@@ -81,25 +81,26 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         event a communication-type excepiton occurs, Home Assistant will
         declare this entry unable to be setup, requiring a reconfiguration or
         restart to bring us back online."""
-    # Prepare storage in hass.data
+    # setup the basic datastructure in hass.
+
     entry_location = hass.data[DOMAIN].setdefault(entry.entry_id, {})
 
-    # Store polling interval
+    # setup the data bridge.
     poll_delta = timedelta(seconds=POLL_INTERVAL)
     entry_location[CONF_SCAN_INTERVAL] = poll_delta
-
-    # Initialize and refresh data bridge
     bridge = get_new_data_bridge(hass, entry)
     await bridge.async_config_entry_first_refresh()
     entry_location["coordinator"] = bridge
 
-    # Forward platforms in batch (preferred over async_forward_entry_setup loop)
-    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    # Setup the platforms.
+    try:
+        await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    except TypeError as err:
+        raise ConfigEntryNotReady from err
 
-    # Listen for option updates
+    # Setup options listener.
     entry.async_on_unload(entry.add_update_listener(opt_update_listener))
     return True
-
 
 def get_new_data_bridge(hass, entry) -> AnycubicDataBridge:
     """Get the data bridge for the given config entry.  The data bridge is


### PR DESCRIPTION
Updates async_forward_entry_setup to async_forward_entry_setups for compatibility with current Home Assistant releases.
The singular API was removed in Home Assistant 2025.6, causing setup to fail with AttributeError on current HA versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration changes now trigger a reload of the integration instead of a full re-setup, ensuring updated settings are applied cleanly and avoiding duplicate device entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/adamoutler/anycubic-homeassistant/pull/17?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->